### PR TITLE
Update defaults

### DIFF
--- a/route.php
+++ b/route.php
@@ -62,16 +62,12 @@ class route extends \WP_REST_Posts_Controller {
 						'sanitize_callback' => '',
 					),
 					'tax_query' => array(
-						'default' => array(),
+						'default' => null,
 						'sanitize_callback' => array( $this, 'sanatize_array'),
 						'validate_callback' => array( $this, 'validate_tax_query' ),
 					),
 					'meta_query' => array(
-						'default' => array(
-							'key' => '',
-							'value' => '',
-							'compare' => '',
-						),
+						'default' => null,
 						'sanitize_callback' => array( $this, 'sanatize_array'),
 						'validate_callback' => array( $this, 'validate_meta_query' ),
 					),


### PR DESCRIPTION
Change the default value for `tax_query` and `meta_query` to `null`, so that the default value doesn't trigger the validation callback.

Without this change, a simple search (no tax query parameters passed) yields a response like this:

```
[{"code":"rest_invalid_param","message":"Invalid parameter(s): Invalid param.","data":{"status":400,"params":{"tax_query":"Invalid param."}}}]
```

Technically the `meta_query` portion is working fine as-is, but I feel that it's more appropriate to have a default of `null` than an array filled with empty values.
