### PR TITLE
added filter to allow custom item responses via theme hooks

### DIFF
--- a/route.php
+++ b/route.php
@@ -155,7 +155,11 @@ class route extends \WP_REST_Posts_Controller {
 
 		$posts = array();
 		foreach ( $query_result as $post ) {
-			$data = $this->prepare_item_for_response( $post, $request );
+			$data = false;
+			$data = apply_filters( 'cwp_swp_api_prepare_item_for_response', $data, $post, $request );
+			if ( empty ( $data ) ) {
+				$data = $this->prepare_item_for_response( $post, $request );
+			}
 			$posts[] = $this->prepare_response_for_collection( $data );
 		}
 


### PR DESCRIPTION
Hi Josh,

I'm working on a project which involves querying a remote api to search in a bunch of CPT's with data. The searching is done through SearchWP, so I was glad to see your Rest API plugin for this to work.

Since the CPT's structures are not regular posts or pages and involve meta fields en connections to other CPT's (with posts-to-posts), I needed a way different reponse object than the regular one provided normally. 

I saw a filter way more downstream to allow for this (rest_prepare_{$this->post_type}). However since I couldn't find any way to  prevent WP to do all this 'work' and then throw it all away later, I thought this early escape path might come in handy.

Please have a look at this pull request and let me know what you think of it.

Thanks,
Ruud
