### PR TITLE
Add check for null query result

### DIFF
--- a/route.php
+++ b/route.php
@@ -151,7 +151,7 @@ class route extends \WP_REST_Posts_Controller {
 			$search = new \WP_Query( $args );
 		}
 
-		$query_result = $search->posts;
+		$query_result = empty($search->posts) ? array() : $search->posts;
 
 		$posts = array();
 		foreach ( $query_result as $post ) {


### PR DESCRIPTION
For some versions of SearchWP, the `posts` field of `SWP_Query` can come back `null`, causing warnings when used in a `foreach` loop. This adds a check for null that ensures an empty array is always used.